### PR TITLE
macOS 10.15 Catalina support

### DIFF
--- a/El Capitan.sublime-theme
+++ b/El Capitan.sublime-theme
@@ -2,32 +2,32 @@
 //
 // FONTS
 //
-    { "class": "tab_label",              "font.face": ".SFNSText-Regular", "settings": [ "!el_capitan_font_default" ] },
-    { "class": "label_control",          "font.face": ".SFNSText-Regular", "settings": [ "!el_capitan_font_default" ] },
-    { "class": "tool_tip_label_control", "font.face": ".SFNSText-Regular", "settings": [ "!el_capitan_font_default" ] },
-    { "class": "sidebar_heading",        "font.face": ".SFNSText-Regular", "settings": [ "!el_capitan_font_default" ] },
-    { "class": "sidebar_label",          "font.face": ".SFNSText-Regular", "settings": [ "!el_capitan_font_default" ] },
+    { "class": "tab_label",              "settings": [ "!el_capitan_font_default" ] },
+    { "class": "label_control",          "settings": [ "!el_capitan_font_default" ] },
+    { "class": "tool_tip_label_control", "settings": [ "!el_capitan_font_default" ] },
+    { "class": "sidebar_heading",        "settings": [ "!el_capitan_font_default" ] },
+    { "class": "sidebar_label",          "settings": [ "!el_capitan_font_default" ] },
 
     // Settings
     { "class": "tab_label",              "font.face": "Helvetica",         "settings": [ "el_capitan_font_helvetica"      ] },
     { "class": "tab_label",              "font.face": "Helvetica Neue",    "settings": [ "el_capitan_font_helvetica_neue" ] },
-    { "class": "tab_label",              "font.face": ".SFNSText-Regular", "settings": [ "el_capitan_font_san_francisco"  ] },
+    { "class": "tab_label",              "settings": [ "el_capitan_font_san_francisco"  ] },
 
     { "class": "label_control",          "font.face": "Helvetica",         "settings": [ "el_capitan_font_helvetica"      ] },
     { "class": "label_control",          "font.face": "Helvetica Neue",    "settings": [ "el_capitan_font_helvetica_neue" ] },
-    { "class": "label_control",          "font.face": ".SFNSText-Regular", "settings": [ "el_capitan_font_san_francisco"  ] },
+    { "class": "label_control",          "settings": [ "el_capitan_font_san_francisco"  ] },
 
     { "class": "tool_tip_label_control", "font.face": "Helvetica",         "settings": [ "el_capitan_font_helvetica"      ] },
     { "class": "tool_tip_label_control", "font.face": "Helvetica Neue",    "settings": [ "el_capitan_font_helvetica_neue" ] },
-    { "class": "tool_tip_label_control", "font.face": ".SFNSText-Regular", "settings": [ "el_capitan_font_san_francisco"  ] },
+    { "class": "tool_tip_label_control", "settings": [ "el_capitan_font_san_francisco"  ] },
 
     { "class": "sidebar_heading",        "font.face": "Helvetica",         "settings": [ "el_capitan_font_helvetica"      ] },
     { "class": "sidebar_heading",        "font.face": "Helvetica Neue",    "settings": [ "el_capitan_font_helvetica_neue" ] },
-    { "class": "sidebar_heading",        "font.face": ".SFNSText-Regular", "settings": [ "el_capitan_font_san_francisco"  ] },
+    { "class": "sidebar_heading",        "settings": [ "el_capitan_font_san_francisco"  ] },
 
     { "class": "sidebar_label",          "font.face": "Helvetica",         "settings": [ "el_capitan_font_helvetica"      ] },
     { "class": "sidebar_label",          "font.face": "Helvetica Neue",    "settings": [ "el_capitan_font_helvetica_neue" ] },
-    { "class": "sidebar_label",          "font.face": ".SFNSText-Regular", "settings": [ "el_capitan_font_san_francisco"  ] },
+    { "class": "sidebar_label",          "settings": [ "el_capitan_font_san_francisco"  ] },
 
 //
 // TABS (REGULAR)


### PR DESCRIPTION
Update the font settings so macOS 10.15 Catalina is supported. 

It's no longer required to specify the `.SFNSText-Regular` font, as it has been replaced by the `.SFNS-Regular` font on Catalina. 

If we just ommit the `font.face` definition, Sublime Text will use macOS Catalina's default system font... which is `.SFNS-Regular`...